### PR TITLE
Update filemagic to new API to fix meme crash

### DIFF
--- a/src/promnesia/sources/auto.py
+++ b/src/promnesia/sources/auto.py
@@ -19,11 +19,11 @@ from ..common import Visit, Url, PathIsh, get_logger, Loc, get_tmpdir, extract_u
 @lru_cache(1)
 def _magic():
     import magic # type: ignore
-    return magic.Magic(mime=True)
+    return magic.Magic(flags=magic.MAGIC_MIME_TYPE)
 
 
 def mime(path: PathIsh) -> str:
-    return _magic().from_file(str(path))
+    return _magic().id_filename(str(path))
 
 Ctx = Sequence[str]
 


### PR DESCRIPTION
When running `scripts/promnesia index` on macOS, I received the following error:

```bash
TypeError: __init__() got an unexpected keyword argument 'mime'
```

From [src/promnesia/sources/auto.py#L22](https://github.com/karlicoss/promnesia/blob/3da00f34163530e28d0a441ab903e3fae392429c/src/promnesia/sources/auto.py#L22):

```python
@lru_cache(1)
def _magic():
    import magic # type: ignore
    return magic.Magic(mime=True)
```

Reviewing the [filemagic docs](https://filemagic.readthedocs.io/en/latest/guide.html#usage), as linked by @flinge in #122, I was able to fix the error by changing the arguments to the `magic.Magic` constructor and use `magic.id_filename()` instead of `magic.from_file()`.

### Notes

I'm not familiar with the Promnesia code base nor `filemagic`, so honestly I'm not sure if this code behaves as it should. Would greatly appreciate your feedback 🙏 

Also, from the [filemagic docs](https://filemagic.readthedocs.io/en/latest/guide.html#usage),

> To ensure that resources are correctly released by magic.Magic, it’s necessary to either explicitly call close() on instances, or use `with` statement.

Since `_magic()` returns an instance of `magic.Magic` without a `close()` or using `with`, the code may currently be leaking file descriptors, though I'm not sure. 

It would probably be good to use a `with` statement unless there's some huge performance or other impact I'm not aware of. This PR does not use `with` because I was trying to make the diff as small as possible.

