### PR TITLE
Enable usage on NixOS

### DIFF
--- a/scripts/promnesia
+++ b/scripts/promnesia
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # this script runs promnesia from the current repository (instead of the installed version)
 
 set -eu


### PR DESCRIPTION
NixOS doesn't use the /bin directory, but still has `bash` in path. Ergo, to get this working properly with NixOS, the path has to be found from the environment.