### PR TITLE
Fix schema in viber locator hrefs from file-->editor

### DIFF
--- a/src/promnesia/sources/viber.py
+++ b/src/promnesia/sources/viber.py
@@ -82,6 +82,7 @@ def messages_query() -> str:
         LEFT JOIN Groups AS G
             ON E.ChatId = G.ChatId
         WHERE
+            M.ClientFlag != 64  AND             /* edited messages */
             text LIKE '%http%'
         ORDER BY time;
         """


### PR DESCRIPTION
In promnesia's search-results tab, links like `file:///.ViberPC/123/viber.db` do not work,
due to security (i guess, bc these urls work fine when pasted in a new tab).

The custom schema `editor:` offers a better UX, 
since it gives the user the choice of which app to use to open the Viber's db-file (e.g. sqlitebrowser`),
when the mime-type is known to the OS (see the 1st resource, below).

These resources are relevant:
* [install a `sqlite` mime-type handler](https://github.com/karlicoss/promnesia/pull/204#issuecomment-785374009)
* [change *firefox* handler](https://github.com/karlicoss/promnesia/pull/204#issuecomment-785376783)
* [karlicoss/open-in-editor](https://github.com/karlicoss/open-in-editor) custom handler

@karlicoss I want your tip about the mime-type handler to be included in the Viber docs;  any idea where or how to include it?