### PR TITLE
FEAT(index) add --sources & --overwrite to CLI to partially update db from config sources

### DIFF
--- a/doc/GUIDE.org
+++ b/doc/GUIDE.org
@@ -110,7 +110,9 @@ Also see [[https://github.com/karlicoss/promnesia/issues/172][issues/172]].
 
 ** partial update
 
-(experimental) Set env variable =PROMNESIA_INDEX_POLICY=update=.
+Only index sources given in =promnesia index --sources SOURCE [SOURCE] ...=
+(or all sources, if no =--sources= given), unless =--overwrite= is given,
+in which case all existing visits are removed from db prior to indexing.
 
 ** exclude files from =auto= indexer
 

--- a/src/promnesia/__main__.py
+++ b/src/promnesia/__main__.py
@@ -5,7 +5,7 @@ import sys
 from typing import List, Tuple, Optional, Dict, Sequence, Iterable, Iterator, Union
 from pathlib import Path
 from datetime import datetime
-from .compat import check_call
+from .compat import check_call, register_argparse_extend_action_in_pre_py38
 from tempfile import TemporaryDirectory
 
 
@@ -292,6 +292,7 @@ def main() -> None:
         :param default_config_path:
             if not given, all :func:`demo_sources()` are run
         """
+        register_argparse_extend_action_in_pre_py38(parser)
         parser.add_argument('--config', type=Path, default=default_config_path, help='Config path')
         parser.add_argument('--dry', action='store_true', help="Dry run, won't touch the database, only print the results out")
         parser.add_argument(

--- a/src/promnesia/compat.py
+++ b/src/promnesia/compat.py
@@ -11,6 +11,25 @@ def _fix(args: Paths) -> List[str]:
     assert not isinstance(args, str), args # just to prevent shell=True calls...
     return list(map(str, args))
 
+
+import argparse
+
+def register_argparse_extend_action_in_pre_py38(parser: argparse.ArgumentParser):
+    import sys
+
+    if sys.version_info < (3, 8):
+
+        class ExtendAction(argparse.Action):
+
+            def __call__(self, parser, namespace, values, option_string=None):
+                items = getattr(namespace, self.dest) or []
+                items.extend(values)
+                setattr(namespace, self.dest, items)
+
+
+        parser.register('action', 'extend', ExtendAction)
+
+
 import subprocess
 
 def run(args: Paths, **kwargs) -> subprocess.CompletedProcess:
@@ -18,10 +37,10 @@ def run(args: Paths, **kwargs) -> subprocess.CompletedProcess:
 
 def check_call(args: Paths, **kwargs) -> None:
     subprocess.check_call(_fix(args), **kwargs)
-    
+
 def check_output(args: Paths, **kwargs) -> bytes:
     return subprocess.check_output(_fix(args), **kwargs)
-    
+
 def Popen(args: Paths, **kwargs) -> subprocess.Popen:
     return subprocess.Popen(_fix(args), **kwargs)
 

--- a/src/promnesia/config.py
+++ b/src/promnesia/config.py
@@ -73,10 +73,9 @@ class Config(NamedTuple):
     @property
     def output_dir(self) -> Path:
         odir = self.OUTPUT_DIR
-        if odir is not None:
-            return Path(odir)
-        else:
-            return default_output_dir()
+        opath = default_output_dir() if odir is None else Path(odir)
+        opath.mkdir(exist_ok=True, parents=True)
+        return opath
 
     @property
     def db(self) -> Path:

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -13,15 +13,7 @@ system = platform.system()
 
 def run_index(cfg: Path, *, update=False) -> None:
     from promnesia.__main__ import do_index
-    if update:
-        ev = 'PROMNESIA_INDEX_POLICY'
-        os.environ[ev] = 'update'
-        try:
-            do_index(cfg)
-        finally:
-            del os.environ[ev]
-    else:
-        do_index(cfg)
+    do_index(cfg, overwrite_db=not update)
 
 
 index = run_index # legacy name


### PR DESCRIPTION
Fixes #20
 
### new `--sources` option(s)
* args can be both Source.name & Source's positional index.
* useful with dynamic *partial* updates, below (now the default), so that the original config file ca be used.

### new `--overwrite` option
- Added a single CLI option almost-described in the 2nd [alternative case](#issuecomment-787917633) explained below,
  due to simplicity.  if missing, defaults to "dynamic partial updates" as described in [this](#issuecomment-788375379) and [this](#issuecomment-788387359).
- Dropped `PROMNESIA_INDEX_POLICY` env-var, since it is the default behavior now.
- Function defaults for `--overwrite` are `False`, as suggested in [the comment below](#issuecomment-778382929).
- Both `promnesia index` & `promnesia demo` sub-commands have been updated.
- All update/overwrite decision logic moved to `promnesia/__main__.py`.:

### Various
- Fix: create db-output directory in advance.