### PR TITLE
convert promnesia to a namespace package

### DIFF
--- a/doc/config.py
+++ b/doc/config.py
@@ -2,7 +2,7 @@
 A more sophisticated example of config for Promnesia
 '''
 
-from promnesia import Source
+from promnesia.common import Source
 
 
 # now, let's import some indexers

--- a/src/promnesia/__init__.py
+++ b/src/promnesia/__init__.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+from .common import PathIsh, Visit, Source, last, Loc, Results, DbVisit, Context, Res
+
+# add deprecation warning so eventually this may converted to a namespace package?
+import warnings
+warnings.warn("DEPRECATED! Please import directly from 'promnesia.common', e.g. 'from promnesia.common import Visit, Source, Results'", DeprecationWarning)

--- a/src/promnesia/__init__.py
+++ b/src/promnesia/__init__.py
@@ -1,8 +1,0 @@
-from pathlib import Path
-from .common import PathIsh, Visit, Source, last, Loc, Results, DbVisit, Context, Res
-
-
-def root() -> Path:
-    r = Path(__file__).absolute().parent.parent.parent
-    assert (r / 'src').exists()
-    return r

--- a/src/promnesia/__init__.pyi
+++ b/src/promnesia/__init__.pyi
@@ -1,2 +1,0 @@
-# NOTE: without __init__.py/__init__.pyi, mypy behaves weird.
-# https://github.com/karlicoss/pymplate/blob/master/src/karlicoss_pymplate/__init__.pyi

--- a/src/promnesia/__init__.pyi
+++ b/src/promnesia/__init__.pyi
@@ -1,0 +1,2 @@
+# NOTE: without __init__.py/__init__.pyi, mypy behaves weird.
+# https://github.com/karlicoss/pymplate/blob/master/src/karlicoss_pymplate/__init__.pyi

--- a/src/promnesia/common.py
+++ b/src/promnesia/common.py
@@ -505,6 +505,12 @@ def get_system_tz() -> pytz.BaseTzInfo:
         logger.error(f"Unknown time zone %s. Falling back to UTC. Please report this as a bug!", zone)
         return pytz.utc
 
+# used in misc/install_server.py
+def root() -> Path:
+    r = Path(__file__).absolute().parent.parent.parent
+    assert (r / 'src').exists()
+    return r
+
 
 def file_mtime(path: PathIsh) -> datetime:
     tz = get_system_tz()

--- a/src/promnesia/misc/config_example.py
+++ b/src/promnesia/misc/config_example.py
@@ -1,4 +1,4 @@
-from promnesia import Source
+from promnesia.common import Source
 from promnesia.sources import auto
 
 '''

--- a/src/promnesia/misc/install_server.py
+++ b/src/promnesia/misc/install_server.py
@@ -12,8 +12,8 @@ SYSTEM = platform.system()
 UNSUPPORTED_SYSTEM = RuntimeError(f'Platform {SYSTEM} is not supported yet!')
 NO_SYSTEMD = RuntimeError('systemd not detected, find your own way to start promnesia automatically')
 
-from .. import root
-from .. import server
+from ..common import root
+from ..server import setup_parser as server_setup_parser
 
 SYSTEMD_TEMPLATE = '''
 [Unit]
@@ -149,4 +149,4 @@ def setup_parser(p: argparse.ArgumentParser) -> None:
 
     p.add_argument('--name', type=str, default=dflt, help='Systemd/launchd service name')
     p.add_argument('--unit-name', type=str, dest='name', help='DEPRECATED, same as --name')
-    server.setup_parser(p)
+    server_setup_parser(p)

--- a/src/promnesia/sources/demo.py
+++ b/src/promnesia/sources/demo.py
@@ -3,7 +3,7 @@ A dummy source, used for testing
 Generates a sequence of fake evenly separated visits
 '''
 
-from .. import Results, Visit, Loc
+from ..common import Results, Visit, Loc
 from datetime import datetime, timedelta
 
 

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -11,8 +11,9 @@ def test_minimal() -> None:
     '''
     Example of a smallest possible config, using a 'demo' source
     '''
+    # import directly from promnesia, not promnesia.common
     cfg = make('''
-from promnesia.common import Source
+from promnesia import Source
 from promnesia.sources import demo
 
 SOURCES = [

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -2,7 +2,7 @@ import pytest
 from more_itertools import ilen
 from typing import Union, Iterable, List
 
-from promnesia import Source
+from promnesia.common import Source
 
 from common import throw
 
@@ -12,7 +12,7 @@ def test_minimal() -> None:
     Example of a smallest possible config, using a 'demo' source
     '''
     cfg = make('''
-from promnesia import Source
+from promnesia.common import Source
 from promnesia.sources import demo
 
 SOURCES = [
@@ -30,7 +30,7 @@ def test_sources_style() -> None:
     Testing 'styles' of specifying sources
     '''
     cfg = make('''
-from promnesia import Source
+from promnesia.common import Source
 from promnesia.sources import demo
 
 SOURCES = [
@@ -79,7 +79,7 @@ def test_sources_style_more():
     '''
     cfg = make('''
 from typing import Iterable
-from promnesia import Visit, Source, Loc
+from promnesia.common import Visit, Source, Loc
 
 def my_indexer() -> Iterable[Visit]:
     from datetime import datetime
@@ -126,7 +126,7 @@ def test_sources_lazy():
     '''
 
     cfg = make('''
-from promnesia import Source
+from promnesia.common import Source
 
 def lazy():
     from promnesia.sources import demo
@@ -200,7 +200,7 @@ SOURCES = []
 
 def test_legacy():
     cfg = make('''
-from promnesia import Source
+from promnesia.common import Source
 from promnesia.sources import demo
 INDEXERS = [
     Source(demo.index, src='legacy name'),

--- a/tests/indexer_test.py
+++ b/tests/indexer_test.py
@@ -271,7 +271,7 @@ def test_hook() -> None:
     import promnesia.sources.shellcmd as custom_gen
     from promnesia.__main__ import iter_all_visits
     with with_config('''
-from promnesia import Source
+from promnesia.common import Source
 from promnesia.sources import demo
 
 SOURCES = [
@@ -279,7 +279,7 @@ SOURCES = [
 ]
 
 from typing import Iterable
-from promnesia import DbVisit, Loc, Res
+from promnesia.common import DbVisit, Loc, Res
 
 def HOOK(visit: Res[DbVisit]) -> Iterable[Res[DbVisit]]:
     # NOTE: might be a good idea to check that the visit is an exception first and yield it intact?

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -137,7 +137,7 @@ def index_some_demo_visits(
             delta=timedelta(seconds={delta.total_seconds()}),
         )
 
-    from promnesia import Source
+    from promnesia.common import Source
     SOURCES = [
         Source(make_visits, name='demo'),
     ]
@@ -230,7 +230,7 @@ def test_index_many(tdir: Path) -> None:
     cfg = tdir / 'test_config.py'
     cfg.write_text(f"""
 from datetime import datetime, timedelta
-from promnesia import Source, Visit, Loc
+from promnesia.common import Source, Visit, Loc
 # TODO def need to allow taking in index function without having to wrap in source?
 def index():
     for i in range(100000):
@@ -255,7 +255,7 @@ def test_indexing_error(tdir: Path) -> None:
 def bad_index():
     import bad_import
     yield from [] # dummy
-from promnesia import Source
+from promnesia.common import Source
 from promnesia.sources import demo
 
 SOURCES = [
@@ -297,7 +297,7 @@ def test_concurrent_indexing(tmp_path: Path, execution_number) -> None:
     cfg_fast = tmp_path / 'config_fast.py'
     cfg = dedent(f'''
     OUTPUT_DIR = r'{tmp_path}'
-    from promnesia import Source
+    from promnesia.common import Source
     from promnesia.sources import demo
     SOURCES = [Source(demo.index, count=COUNT)]
     ''')

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -210,7 +210,7 @@ def test_query_while_indexing(tmp_path: Path) -> None:
     cfg.write_text(dedent(f'''
     OUTPUT_DIR = r'{tmp_path}'
 
-    from promnesia import Source
+    from promnesia.common import Source
     from promnesia.sources import demo
     # index stupid amount of visits to increase time spent in database serialization
     SOURCES = [Source(demo.index, count=100000)]


### PR DESCRIPTION
initial attempt at converting this to a namespace package

this allows someone to install their own modules alongside `promnesia.sources`, and possibly override `sources` with their own changes

For reference: https://github.com/karlicoss/HPI/blob/master/doc/MODULE_DESIGN.org#namespace-packages

not being familiar with promnesia, was pretty painless to create a Source for my discord module

https://github.com/seanbreckenridge/promnesia
https://github.com/seanbreckenridge/HPI/blob/master/my/discord.py

![](https://i.imgur.com/e7qsMO1.png)

