### PR TITLE
sources.github: optional flag to render markdown

### DIFF
--- a/src/promnesia/sources/github.py
+++ b/src/promnesia/sources/github.py
@@ -2,6 +2,8 @@
 Uses [[https://github.com/karlicoss/HPI][HPI]] github module
 '''
 
+# Note: requires the 'mistletoe' module if you enable render_markdown
+
 from typing import Optional, Set
 
 from ..common import Results, Visit, Loc, iter_urls, logger

--- a/src/promnesia/sources/github.py
+++ b/src/promnesia/sources/github.py
@@ -2,12 +2,22 @@
 Uses [[https://github.com/karlicoss/HPI][HPI]] github module
 '''
 
-from ..common import Results, Visit, Loc, iter_urls
+from typing import Optional, Set
+
+from ..common import Results, Visit, Loc, iter_urls, logger
 
 
-def index() -> Results:
+def index(*, render_markdown: bool = False) -> Results:
     from . import hpi
     from my.github.all import events
+
+    if render_markdown:
+        try:
+            from .markdown import TextParser, extract_from_text
+        except ImportError as import_err:
+            logger.exception(import_err)
+            logger.critical("Could not import markdown module to render github body markdown. Try 'python3 -m pip install mistletoe'")
+            render_markdown = False
 
     for e in events():
         if isinstance(e, Exception):
@@ -16,14 +26,19 @@ def index() -> Results:
         if e.link is None:
             continue
 
+        # if enabled, convert the (markdown) body to HTML
+        context: Optional[str] = e.body
+        if e.body is not None and render_markdown:
+            context = TextParser(e.body)._doc_ashtml()
+
         # locator should link back to this event
         loc = Loc.make(title=e.summary, href=e.link)
 
-        # visit which include links to this event in particular
+        # visit which links back to this event in particular
         yield Visit(
             url=e.link,
             dt=e.dt,
-            context=e.body,
+            context=context,
             locator=loc,
         )
 
@@ -31,23 +46,42 @@ def index() -> Results:
             yield Visit(
                 url=url,
                 dt=e.dt,
-                context=e.body,
+                context=context,
                 locator=loc,
             )
 
         if e.body is None:
             continue
 
-        # TODO: probably includes lots of filenames
-        # which get mismatched as urls? check if they're
-        # prefixed with http/www/find some way to ignore
-        # filenames (ends with .py? .js? .html?)
-        #
         # extract any links found in the body
+        #
+        # Note: this set gets reset every event, is here to
+        # prevent duplicates between URLExtract and the markdown parser
+        emitted: Set[str] = set()
         for url in iter_urls(e.body):
+            if url in emitted:
+                continue
             yield Visit(
                 url=url,
                 dt=e.dt,
-                context=e.body,
+                context=context,
                 locator=loc,
             )
+            emitted.add(url)
+
+        # extract from markdown links like [link text](https://...)
+        # incase URLExtract missed any somehow
+        if render_markdown:
+            for res in extract_from_text(e.body):
+                if isinstance(res, Exception):
+                    yield res
+                    continue
+                if res.url in emitted:
+                    continue
+                yield Visit(
+                    url=res.url,
+                    dt=e.dt,
+                    context=context,
+                    locator=loc,
+                )
+                emitted.add(res.url)


### PR DESCRIPTION
allows the user to pass the 'render_markdown'
flag to convert the text in the github body (typically
markdown) to HTML, so it renders nicely in the sidebar

disabled by default, as it might break is inline highlights

---

was a bit unsure how to add this to reddit without adding a
bunch of kwargs like `render_markdown: bool = False` to 
[all the functions here](https://github.com/karlicoss/promnesia/blob/master/src/promnesia/sources/reddit.py#L51-L100)..
Also the `TextParser` import should probably happen inside the `index` function...
but then it needs to be passed to `_from_common` somehow.

Perhaps could just use a global var which is only set in `index` and then
used in `_from_common` if `render_markdown` is True

not sure what the best way to solve this, will think about it...

