### PR TITLE
Missing Config Flag for `promnesia config create`

### DIFF
--- a/src/promnesia/__main__.py
+++ b/src/promnesia/__main__.py
@@ -352,6 +352,9 @@ def main() -> None:
     ccp.add_argument('--config', type=Path, default=default_config_path(), help='Config path')
 
     icp = scp.add_parser('create', help='Create user config')
+    icp.add_argument(
+        "--config", type=Path, default=default_config_path(), help="Config path"
+    )
     icp.set_defaults(func=config_create)
 
     dp = subp.add_parser('doctor', help='Troubleshooting assistant')


### PR DESCRIPTION
As a Mac User couldnt figure out why it kept installing at `~/Library/Application Support/promnesia` no matter what I did.