### PR TITLE
FIX signal & report cleared visits

### DIFF
--- a/src/promnesia/dump.py
+++ b/src/promnesia/dump.py
@@ -72,17 +72,21 @@ def visits_to_sqlite(vit: Iterable[Res[DbVisit]], *, overwrite_db: bool) -> List
     meta.create_all()
 
     cleared: Set[str] = set()
+    ncleared = 0
     with engine.begin() as conn:
         for chunk in chunked(vit_ok(), n=_CHUNK_BY):
             srcs = set(v.src or '' for v in chunk)
             new = srcs.difference(cleared)
+
             for src in new:
-                conn.execute(table.delete().where(table.c.src == src))
+                cur = conn.execute(table.delete().where(table.c.src == src))
+                ncleared += conn.execute("SELECT changes()").fetchone()[0]
                 cleared.add(src)
 
             bound = [binder.to_row(x) for x in chunk]
             # pylint: disable=no-value-for-parameter
             conn.execute(table.insert().values(bound))
+    logger.info("Cleared %s old visits from: %s", ncleared, cleared)
 
     if overwrite_db:
         shutil.move(str(tpath), str(db_path))
@@ -90,7 +94,9 @@ def visits_to_sqlite(vit: Iterable[Res[DbVisit]], *, overwrite_db: bool) -> List
     errs = '' if errors == 0 else f', {errors} ERRORS'
     total = ok + errors
     what = 'overwritten' if overwrite_db else 'updated'
-    logger.info('%s database "%s". %d total (%d OK%s)', what, db_path, total, ok, errs)
+    logger.info(
+        '%s database "%s". %d total (%d OK%s, %d cleared, +%d more)',
+        what, db_path, total, ok, errs, ncleared, ok - ncleared)
     res: List[Exception] = []
     if total == 0:
         res.append(RuntimeError('No visits were indexed, something is probably wrong!'))

--- a/src/promnesia/sources/signal.py
+++ b/src/promnesia/sources/signal.py
@@ -61,14 +61,14 @@ def index(
     resolved_db_paths = collect_db_paths(*db_paths, append=append_platform_path)
     logger.debug("Paths to harvest: %s", db_paths)
     if not http_only:
-        messages_query += "\nWHERE body LIKE '%http%'"
+        sql_query = f"{messages_query}\nWHERE body LIKE '%http%'"
 
     for db_path in resolved_db_paths:
         logger.info("Ciphered db to harvest %s", db_path)
         assert db_path.is_file(), f"Is it a (Signal-desktop sqlite) file? {db_path}"
         yield from _harvest_db(
             db_path,
-            messages_query,
+            sql_query,
             override_key=override_key,
             locator_schema=locator_schema,
         )

--- a/src/promnesia/sources/viber.py
+++ b/src/promnesia/sources/viber.py
@@ -2,7 +2,6 @@
 Adapted from `telegram.py` to read from `~/.ViberPC/XYZ123/viber.db`
 """
 
-import json
 import logging
 import textwrap
 from os import PathLike


### PR DESCRIPTION
- FIX(signal) undefined var when `http_only` flag is given
- enh(harvesting) log the number of rows cleared (good to know when `--source` given)
- fix(viber) delete leftover `json` import (redundant since sqlite-json extensions were used)
