### PR TITLE
[setup] update tzlocal version and object access

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def main() -> None:
         python_requires='>=3.6',
         install_requires=[
             'appdirs', # for portable user directories detection
-            'tzlocal',
+            'tzlocal>=2.1',
             'more_itertools',
             'pytz',
             'sqlalchemy', # DB api

--- a/src/promnesia/common.py
+++ b/src/promnesia/common.py
@@ -488,7 +488,7 @@ def traverse(root: Path, *, follow: bool=True, ignore: List[str]=[]) -> Iterable
 def get_system_zone() -> str:
     try:
         import tzlocal # type: ignore
-        return tzlocal.get_localzone().zone
+        return tzlocal.get_localzone().key
     except Exception as e:
         logger.exception(e)
         logger.error("Couldn't determine system timezone. Falling back to UTC. Please report this as a bug!")


### PR DESCRIPTION
Recent versions of tzlocal access the time zone with the `key` object. Enforce version to be the newer API (>=2.1) and change the way it's accessed.