### PR TITLE
sources/html: refactor to allow usage as lib func

### DIFF
--- a/src/promnesia/sources/html.py
+++ b/src/promnesia/sources/html.py
@@ -3,6 +3,7 @@ Extracts links from HTML files
 '''
 
 from pathlib import Path
+from typing import Iterator, Tuple
 from ..common import PathIsh, Visit, Loc, Results, file_mtime
 
 # TODO present error summary in the very end; import errors -- makes sense to show 
@@ -10,17 +11,27 @@ from ..common import PathIsh, Visit, Loc, Results, file_mtime
 
 from bs4 import BeautifulSoup # type: ignore[import]
 
-def extract_from_file(fname: PathIsh) -> Results:
-    ts = file_mtime(fname)
+Url = Tuple[str, str]
 
-    soup = BeautifulSoup(Path(fname).read_text(errors='replace'), 'lxml')
+def extract_urls_from_html(s: str) -> Iterator[Url]:
+    """
+    Helper method to extract URLs from any HTML, so this could
+    potentially be used by other modules
+    """
+    soup = BeautifulSoup(s, 'lxml')
     for a in soup.find_all('a'):
         href = a.attrs.get('href')
         if href is None or ('://' not in href):
             # second condition means relative link
             continue
         text = a.text
+        yield (href, text)
 
+
+def extract_from_file(fname: PathIsh) -> Results:
+    ts = file_mtime(fname)
+
+    for href, text in extract_urls_from_html(Path(fname).read_text(errors='replace')):
         yield Visit(
             url=href,
             dt=ts,


### PR DESCRIPTION
While [trying to parse HTML fragments of local email files](https://github.com/seanbreckenridge/promnesia/issues/1), wanted to try and use the `sources.html` logic

This refactors the bs4 parsing into a separate function so its usable as a library function - doesn't change any other behavior