### PR TITLE
core: support tzlocal 4.x for get_system_zone

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,8 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest] # todo windows-latest?
         python-version: [3.6, 3.7, 3.8]
+        # seems like 3.6 isn't available on their osx image anymore
+        exclude: [{platform: macos-latest, python-version: 3.6}]
 
     runs-on: ${{ matrix.platform }}
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def main() -> None:
         python_requires='>=3.6',
         install_requires=[
             'appdirs', # for portable user directories detection
-            'tzlocal>=3.0',
+            'tzlocal',
             'more_itertools',
             'pytz',
             'sqlalchemy', # DB api

--- a/src/promnesia/common.py
+++ b/src/promnesia/common.py
@@ -488,7 +488,13 @@ def traverse(root: Path, *, follow: bool=True, ignore: List[str]=[]) -> Iterable
 def get_system_zone() -> str:
     try:
         import tzlocal
-        return tzlocal.get_localzone().key # type: ignore[attr-defined] # mypy stubs aren't aware of api change yet (see https://github.com/python/typeshed/issues/6038)
+        # note: tzlocal mypy stubs aren't aware of api change yet (see https://github.com/python/typeshed/issues/6038)
+        try:
+            # 4.0 way
+            return tzlocal.get_localzone_name() # type: ignore[attr-defined]
+        except AttributeError as e:
+            # 2.0 way
+            return tzlocal.get_localzone().zone # type: ignore[attr-defined]
     except Exception as e:
         logger.exception(e)
         logger.error("Couldn't determine system timezone. Falling back to UTC. Please report this as a bug!")


### PR DESCRIPTION
kind of related to bc9d9034aa7d83c12e24c60aac50c965513ef9ae

if you have tzlocal 3.x, best to updgrade it to 4.x (see https://github.com/regebro/tzlocal/issues/121)

fixes https://github.com/karlicoss/promnesia/issues/253