### PR TITLE
org: index URLs in properties

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ DEPS_SOURCES = {
         'mistletoe',
     ],
     ('org'     , 'dependencies for sources.org'     ): [
-        'orgparse>=0.2.0',
+        'orgparse>=0.3.0',
     ],
     ('telegram', 'dependencies for sources.telegram'): [
         'dataset',

--- a/src/promnesia/sources/org.py
+++ b/src/promnesia/sources/org.py
@@ -112,6 +112,15 @@ def iter_org_urls(n: OrgNode) -> Iterator[Res[Url]]:
         yield from iter_urls(heading, syntax='org')
 
     try:
+        values = n.properties.values()
+    except Exception as e:
+        logger.exception(e)
+        yield e
+    else:
+        for v in values:
+            yield from iter_urls(str(v), syntax='org')
+
+    try:
         content = get_body_compat(n)
     except Exception as e:
         logger.exception(e)

--- a/tests/test_org_indexer.py
+++ b/tests/test_org_indexer.py
@@ -50,3 +50,9 @@ def test_heading() -> None:
     }
 
 
+def test_url_in_properties() -> None:
+    items = [v if isinstance(v, Visit) else throw(v) for v in extract_from_file(tdata('auto/orgs/file4.org'))]
+
+    assert len(items) == 2, items
+    assert items[0].url == 'https://example.org/ref_example'
+    assert items[1].url == 'http://example.org/a_test'

--- a/tests/testdata/auto/orgs/file4.org
+++ b/tests/testdata/auto/orgs/file4.org
@@ -1,0 +1,7 @@
+:PROPERTIES:
+:ID:       1554c141-9567-4345-99d9-7c5e2853dbaa
+:ROAM_REFS: https://example.org/ref_example
+:END:
+#+title: A Ref Example
+
+We need [[http://example.org/a_test][a test]]!


### PR DESCRIPTION
This fixes #218, based on the suggestions of @amoghpj and @hrehfeld.

I've eliminated the `if not n.is_root():` test from those since, after all, files can have properties, too.