### PR TITLE
remove spaces in source name (taken from config)

### DIFF
--- a/extension/src/display.js
+++ b/extension/src/display.js
@@ -38,7 +38,7 @@ const HTML_MARKER = '!html ';
 type CssClass = string
 export function asClass(x: string): CssClass {
     // todo meh. too much trouble to fix properly...
-    const res = x.replace(/[^0-9a-z_-]/, '_')
+    const res = x.replace(/\s/g, '');
     return res.length == 0 ? 'bad_class' : res
 }
 
@@ -110,7 +110,7 @@ export class Binder {
         const dt_c = child(header, 'span', ['datetime']);
         const time_c = child(dt_c, 'span', ['time']);
         const date_c = child(dt_c, 'span', ['date']);
-        item.setAttribute('data-sources', tags.join(' '));
+        item.setAttribute('data-sources', asClass(tags.join(' ')));
 
         const child_link = child(relative_c, 'a');
         // ugh. not sure why opening in new tab doesn't work :(
@@ -126,7 +126,7 @@ export class Binder {
         }
         for (const tag of tags) {
             const tag_c = child(tags_c, 'span', ['src', asClass(tag)]);
-            tchild(tag_c, tag);
+            tchild(tag_c, asClass(tag));
         }
         tchild(date_c, dates);
 

--- a/extension/src/sidebar.js
+++ b/extension/src/sidebar.js
@@ -422,13 +422,13 @@ async function* _bindSidebarData(response: Visits) {
             tag = 'all';
             predicate = () => true;
         } else {
-            predicate = t => t == tag;
+            predicate = t => t == asClass(tag);
         }
 
         // TODO show total counts?
         // TODO if too many tags, just overlap on the seconds line
         const tag_c = binder.makeChild(all_tags_c, 'span', ['src', asClass(tag)])
-        binder.makeTchild(tag_c, `${tag} (${count})`);
+        binder.makeTchild(tag_c, `${asClass(tag)} (${count})`);
         // TODO checkbox??
         tag_c.addEventListener('click', () => {
             for (const x of items.children) {


### PR DESCRIPTION
A lot of chars allowed...
https://stackoverflow.com/a/6732899/706389
> So, if you need to turn a random string into a CSS class name: take care of NUL and space, and escape (accordingly for CSS or HTML). Done.

Should fix (full or partial) this issue - https://memex.zulipchat.com/#narrow/stream/279600-promnesia/topic/markdown.20link.20extraction