### PR TITLE
Use sqlcipher3 instead of pysqlcypher3

### DIFF
--- a/src/promnesia 👁canonical: github.com/karlicoss/promnesia/tree/master/src/promnesia×?sources : firefox02/05/2022, 15:07:54/sources 👁canonical: github.com/karlicoss/promnesia/tree/master/src/promnesia/sources×?sources : firefox02/05/2022, 15:07:56/signal.py
+++ b/src/promnesia 👁canonical: github.com/karlicoss/promnesia/tree/master/src/promnesia×?sources : firefox02/05/2022, 15:07:54/sources 👁canonical: github.com/karlicoss/promnesia/tree/master/src/promnesia/sources×?sources : firefox02/05/2022, 15:07:56/signal.py
@@ -334,7 +334,7 @@ def connect_db(
                 ) from None
             db = sqlite3.connect(f"file:{decrypted_file}?mode=ro", uri=True)
         else:
-            from pysqlcipher3 import dbapi2  # type: ignore[import]
+            from sqlcipher3 import dbapi2  # type: ignore[import]
 
             db = dbapi2.connect(f"file:{db_path}?mode=ro", uri=True)
             # Param-binding doesn't work for pragmas, so use a direct string concat.


### PR DESCRIPTION
Just a heads up. For user on version 3.10 of python, the signal source will not work by default because it uses pysqlcipher. The pysqlcipher3 module does not work with Python 3.10, solved this by installing sqlcipher3 ( https://pypi.org/project/sqlcipher3/ ) and substitute the import on line 340: