### PR TITLE
extension hotfix for discontinued shallalist lists/mirror

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "promnesia",
-  "version": "1.1.1",
-  "version_name": "released on 2022.05.12",
+  "version": "1.1.2",
+  "version_name": "released on 2022.05.24",
   "description": "Recall what you already visited, why and in which context",
   "main": "dist/background.js",
   "scripts": {


### PR DESCRIPTION
- replace shallalist links with my forked version (at least it won't disappear)
- use main branch instead of master to reflect what mirror did
- make filterlist fetching defensive just in case

should resolve https://github.com/karlicoss/promnesia/issues/325