### PR TITLE
Pocket improvements

### DIFF
--- a/src/promnesia/cannon.py
+++ b/src/promnesia/cannon.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Experimental libarary for normalising domain names and urls to achieve 'canonical' urls for content.
-E.g. 
+E.g.
  https://mobile.twitter.com/demarionunn/status/928409560548769792
 and
  https://twitter.com/demarionunn/status/928409560548769792
@@ -55,6 +55,9 @@ dom_subst = [
     ('np.reddit.'     , 'reddit.'),
 
     ('m.facebook.'    , 'facebook.'),
+    # app.getpocket.com is the canonical domain in the JSON returned by
+    # https://github.com/karlicoss/pockexport, so let's canonicalize to that.
+    ('getpocket.'     , 'app.getpocket.'),
 ]
 
 def canonify_domain(dom: str) -> str:
@@ -626,6 +629,14 @@ FB_PATTERNS = [
     r'F/notes/U/P',
 ]
 
+PKP = r'^(app)?\.getpocket\.com'
+
+PK_PATTERNS = [
+    {
+        'ID': r'\d+',
+    },
+    PKP + '/read/ID',
+]
 
 # NOTE: right, I think this is just for analysis so far... not actually used
 PATTERNS = {
@@ -636,6 +647,7 @@ PATTERNS = {
     'stackoverflow': SO_PATTERNS,
     'facebook'  : FB_PATTERNS,
     'wikipedia' : WK_PATTERNS,
+    'pocket'    : PK_PATTERNS,
     # 'news.ycombinator.com': YC_PATTERNS,
 }
 

--- a/src/promnesia/sources/pocket.py
+++ b/src/promnesia/sources/pocket.py
@@ -7,16 +7,22 @@ from ..common import Visit, Loc, Results
 def index() -> Results:
     from . import hpi
     from my.pocket import articles
+
     # TODO use docstring from my. module? E.g. describing which pocket format is expected
 
     for a in articles():
-        loc = Loc.make(title='pocket', href=a.pocket_link)
+        title = a.json.get('resolved_title', None) or a.json.get('given_title', 'pocket')
+        loc = Loc.make(title=title, href=a.pocket_link)
+        # Add a reverse locator so that the Promnesia browser extension shows a
+        # link on the Pocket page back to the original URL.
+        loc_rev = Loc.make(title=title, href=a.url)
         hls = a.highlights
+        excerpt = a.json.get('excerpt', None)
         if len(hls) == 0:
             yield Visit(
                 url=a.url,
                 dt=a.added,
-                context=None,
+                context=excerpt,
                 locator=loc,
             )
         for hl in hls:

--- a/tests/cannon.py
+++ b/tests/cannon.py
@@ -121,6 +121,19 @@ def test_hackernews(url, expected):
 def test_reddit(url, expected):
     assert canonify(url) == expected
 
+# ugh. good example of motication for cannon.py?
+@param('url,expected', [
+    ( 'https://app.getpocket.com/read/3479402594'
+    , 'app.getpocket.com/read/3479402594'
+    ),
+
+    ( 'https://getpocket.com/read/3479402594'
+    , 'app.getpocket.com/read/3479402594'
+    ),
+])
+def test_pocket(url, expected):
+    assert canonify(url) == expected
+
 @pytest.mark.parametrize("url,expected", [
     # TODO ?? 'https://groups.google.com/a/list.hypothes.is/forum/#!topic/dev/kcmS7H8ssis',
     #


### PR DESCRIPTION
- Set `locator_title` and `context` from `pockexport` data.
- Add a backlink `Visit` with `url` set to the Pocket URL and `locator`
  set to the original URL.
- Canonicalize `getpocket.com` to `app.getpocket.com`.

Fix https://github.com/karlicoss/promnesia/issues/294