### PR TITLE
enh: log tracebacks of collected source-errors to aid debugging

### DIFF
--- a/src/promnesia/__main__.py
+++ b/src/promnesia/__main__.py
@@ -98,7 +98,7 @@ def do_index(
     if len(errors) > 0:
         logger.error('%d errors, printing them out:', len(errors))
         for e in errors:
-            logger.error('    %s', e)
+            logger.error('    %s', e, exc_info=e)
         logger.error('%d errors, exit code 1', len(errors))
         sys.exit(1)
 


### PR DESCRIPTION
Without it, logs don't reveal the actual place of the error produced from some SOURCE:

```python
[ERROR   2022-09-14 10:46:05 promnesia __main__.py:99] 1 errors, printing them out:
[ERROR   2022-09-14 10:46:05 promnesia __main__.py:101]     'ModuleNotFoundError' object has no attribute 'norm_url'

```

Now it becomes like that:

```python
[ERROR   2022-09-14 12:20:48 promnesia __main__.py:99] 1 errors, printing them out:
[ERROR   2022-09-14 12:20:48 promnesia __main__.py:101]     'ModuleNotFoundError' object has no attribute 'norm_url'
    Traceback (most recent call last):
      File ".../promnesia.git/src/promnesia/__main__.py", line 57, in iter_all_visits
        yield from hook(v)
      File "~/.config/promnesia/config.py", line 116, in HOOK
        if "github.com" in v.norm_url:
    AttributeError: 'ModuleNotFoundError' object has no attribute 'norm_url'
``` 