### PR TITLE
remove dataset usage from modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ DEPS_SOURCES = {
         'orgparse>=0.3.0',
     ],
     ('telegram', 'dependencies for sources.telegram'): [
-        'dataset',
+        # used to depend on 'dataset', keeping for backwards compatibility
     ],
 }
 

--- a/src/promnesia/compat.py
+++ b/src/promnesia/compat.py
@@ -69,3 +69,16 @@ else:
     else:
         # todo could also use NamedTuple?
         Protocol = object
+
+
+if sys.version_info[:2] >= (3, 8):
+    from typing import Literal
+else:
+    if TYPE_CHECKING:
+        from typing_extensions import Literal
+    else:
+        # erm.. I guess as long as it's not crashing, whatever...
+        class _Literal:
+            def __getitem__(self, args):
+                pass
+        Literal = _Literal()

--- a/src/promnesia/sqlite.py
+++ b/src/promnesia/sqlite.py
@@ -1,0 +1,43 @@
+from contextlib import contextmanager
+import sqlite3
+from typing import Callable, Optional, Any, Iterator, Union
+
+from .common import PathIsh
+from .compat import Literal
+
+# NOTE: copy pasted from HPI
+
+SqliteRowFactory = Callable[[sqlite3.Cursor, sqlite3.Row], Any]
+
+def dict_factory(cursor, row):
+    fields = [column[0] for column in cursor.description]
+    return {key: value for key, value in zip(fields, row)}
+
+
+Factory = Union[SqliteRowFactory, Literal['row', 'dict']]
+
+@contextmanager
+def sqlite_connection(db: PathIsh, *, immutable: bool=False, row_factory: Optional[Factory]=None) -> Iterator[sqlite3.Connection]:
+    dbp = f'file:{db}'
+    # https://www.sqlite.org/draft/uri.html#uriimmutable
+    if immutable:
+        dbp = f'{dbp}?immutable=1'
+    row_factory_: Any = None
+    if row_factory is not None:
+        if callable(row_factory):
+            row_factory_ = row_factory
+        elif row_factory == 'row':
+            row_factory_ = sqlite3.Row
+        elif row_factory == 'dict':
+            row_factory_ = dict_factory
+        else:
+            raise RuntimeError("should not happen")
+
+    conn = sqlite3.connect(dbp, uri=True)
+    try:
+        conn.row_factory = row_factory_
+        with conn:
+            yield conn
+    finally:
+        # Connection context manager isn't actually closing the connection, only keeps transaction
+        conn.close()


### PR DESCRIPTION
its unmaintained & broken due to sqlalchemy 2.0 updates, and feels just easier to use builtin sqlite

resolves https://github.com/karlicoss/promnesia/issues/368

cc @ankostis I also migrated Viber module -- kind of in the blind since I don't use viber myself, but looks like a fairly simple change & checked by mypy, so expecting it to just work