### PR TITLE
backend: get rid of cachew dependency for marshalling DbVisit into sqlite

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,7 @@ def main() -> None:
             'tzlocal',
             'more_itertools',
             'pytz',
-            'sqlalchemy', # DB api
-            'cachew>=0.8.0', # caching with type hints
+            'sqlalchemy>=2.0',  # DB api
 
             *DEPS_INDEXER,
             *DEPS_SERVER,
@@ -84,8 +83,6 @@ DEPS_SERVER = [
 ]
 
 DEPS_SOURCES = {
-    # TODO make cachew optional?
-    # althrough server uses it so not sure...
     ('optional', 'dependencies that bring some bells & whistles'): [
         'logzero', # pretty colored logging
         'python-magic', # better mimetype decetion

--- a/src/promnesia/__main__.py
+++ b/src/promnesia/__main__.py
@@ -18,7 +18,7 @@ from . import server
 from .misc import install_server
 from .common import Extractor, PathIsh, logger, get_tmpdir, DbVisit, Res
 from .common import Source, get_system_tz, user_config_file, default_config_path
-from .dump import visits_to_sqlite
+from .database.dump import visits_to_sqlite
 from .extract import extract_visits
 
 

--- a/src/promnesia/compare.py
+++ b/src/promnesia/compare.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Any, NamedTuple, Optional, Iterator, Set, Tuple
 
 
 from .common import DbVisit, Url, PathWithMtime # TODO ugh. figure out pythonpath
+from .database.load import row_to_db_visit
 
 # TODO include latest too?
 # from cconfig import ignore, filtered
@@ -139,10 +140,10 @@ def compare_files(*files: Path, log=True) -> Iterator[Tuple[str, DbVisit]]:
         this_dts = name[0: name.index('.')] # can't use stem due to multiple extensions..
 
         from promnesia.server import _get_stuff # TODO ugh
-        engine, binder, table = _get_stuff(PathWithMtime.make(f))
+        engine, table = _get_stuff(PathWithMtime.make(f))
 
         with engine.connect() as conn:
-            vis = [binder.from_row(row) for row in conn.execute(table.select())]  # type: ignore[var-annotated]
+            vis = [row_to_db_visit(row) for row in conn.execute(table.select())]  # type: ignore[var-annotated]
 
         if last is not None:
             between = f'{last_dts}:{this_dts}'

--- a/src/promnesia/config.py
+++ b/src/promnesia/config.py
@@ -69,6 +69,8 @@ class Config(NamedTuple):
 
     @property
     def cache_dir(self) -> Optional[Path]:
+        # TODO we used to use this for cachew, but it's best to rely on HPI modules etc to cofigure this
+        # keeping just in case for now
         cd = self.CACHE_DIR
         cpath: Optional[Path]
         if cd is None:

--- a/src/promnesia/database/common.py
+++ b/src/promnesia/database/common.py
@@ -1,0 +1,66 @@
+from datetime import datetime
+from typing import Sequence, Tuple
+
+from sqlalchemy import (
+    Column,
+    Integer,
+    Row,
+    String,
+)
+
+# TODO maybe later move DbVisit here completely?
+# kinda an issue that it's technically an "api" because hook in config can patch up DbVisit
+from ..common import DbVisit, Loc
+
+
+def get_columns() -> Sequence[Column]:
+    # fmt: off
+    res: Sequence[Column] = [
+        Column('norm_url'     , String()),
+        Column('orig_url'     , String()),
+        Column('dt'           , String()),
+        Column('locator_title', String()),
+        Column('locator_href' , String()),
+        Column('src'          , String()),
+        Column('context'      , String()),
+        Column('duration'     , Integer())
+    ]
+    # fmt: on
+    assert len(res) == len(DbVisit._fields) + 1  # +1 because Locator is 'flattened'
+    return res
+
+
+def db_visit_to_row(v: DbVisit) -> Tuple:
+    # ugh, very hacky...
+    # we want to make sure the resulting tuple only consists of simple types
+    # so we can use dbengine directly
+    dt_s = v.dt.isoformat()
+    row = (
+        v.norm_url,
+        v.orig_url,
+        dt_s,
+        v.locator.title,
+        v.locator.href,
+        v.src,
+        v.context,
+        v.duration,
+    )
+    return row
+
+
+def row_to_db_visit(row: Sequence) -> DbVisit:
+    (norm_url, orig_url, dt_s, locator_title, locator_href, src, context, duration) = row
+    dt_s = dt_s.split()[0]  # backwards compatibility: previously it could be a string separated with tz name
+    dt = datetime.fromisoformat(dt_s)
+    return DbVisit(
+        norm_url=norm_url,
+        orig_url=orig_url,
+        dt=dt,
+        locator=Loc(
+            title=locator_title,
+            href=locator_href,
+        ),
+        src=src,
+        context=context,
+        duration=duration,
+    )

--- a/src/promnesia/sources/browser_legacy.py
+++ b/src/promnesia/sources/browser_legacy.py
@@ -9,8 +9,14 @@ import pytz
 from ..common import PathIsh, Results, Visit, Loc, logger, Second, is_sqlite_db
 from .. import config
 
-# todo mcachew?
-from cachew import cachew
+try:
+    from cachew import cachew  # type: ignore[import-not-found]
+except ModuleNotFoundError as me:
+    if me.name != 'cachew':
+        raise me
+    # this module is legacy anyway, so just make it defensive
+    def cachew(*args, **kwargs):  # type: ignore[no-redef]
+        return lambda f: f
 
 
 def index(p: PathIsh) -> Results:

--- a/src/promnesia/sources/takeout_legacy.py
+++ b/src/promnesia/sources/takeout_legacy.py
@@ -34,7 +34,15 @@ from .. import config
 
 
 from more_itertools import unique_everseen
-from cachew import cachew
+
+try:
+    from cachew import cachew  # type: ignore[import-not-found]
+except ModuleNotFoundError as me:
+    if me.name != 'cachew':
+        raise me
+    # this module is legacy anyway, so just make it defensive
+    def cachew(*args, **kwargs):  # type: ignore[no-redef]
+        return lambda f: f
 
 
 # TODO use CPath? Could encapsulate a path within an archive *or* within a directory

--- a/src/promnesia/tests/test_db_dump.py
+++ b/src/promnesia/tests/test_db_dump.py
@@ -13,9 +13,10 @@ import pytest
 import pytz
 
 
-from ..common import DbVisit, Loc, Res
-from ..dump import visits_to_sqlite
-from ..read_db import get_all_db_visits
+from ..common import Loc, Res
+from ..database.common import DbVisit
+from ..database.dump import visits_to_sqlite
+from ..database.load import get_all_db_visits
 from ..sqlite import sqlite_connection
 
 from .common import gc_control, running_on_ci
@@ -73,9 +74,6 @@ def test_one_visit(tmp_path: Path) -> None:
 
     assert sqlite_visit == {
         'context': None,
-        # NOTE: at the moment date is dumped like this because of cachew NTBinder
-        # however it's not really necessary for promnesia (and possibly results in a bit of performance hit)
-        # I think we could just convert to a format sqlite supports, just need to make it backwards compatible
         'dt': '2023-11-14T23:11:01+01:00',
         'duration': 123,
         'locator_href': 'https://whatever.com',
@@ -109,7 +107,8 @@ CREATE TABLE visits (
 );
 '''
         )
-        # this tz format might occur in databases that were created when promnesia was using cachew NTBinder
+        # this dt format (zone name after iso timestap) might occur in legacy databases
+        # (that were created when promnesia was using cachew NTBinder)
         conn.execute(
             '''
 INSERT INTO visits VALUES(

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -10,7 +10,7 @@ import pytest
 from common import under_ci, DATA, GIT_ROOT, promnesia_bin
 
 from promnesia.common import _is_windows, DbVisit
-from promnesia.read_db import get_all_db_visits
+from promnesia.database.load import get_all_db_visits
 
 
 def run_index(cfg: Path, *, update=False) -> None:

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -64,6 +64,7 @@ def wserver(db: Optional[PathIsh]=None): # TODO err not sure what type should it
 @contextmanager
 def _test_helper(tmp_path):
     tdir = Path(tmp_path)
+    # TODO probably don't need this anymore?
     cache_dir = tdir / 'cache'
     cache_dir.mkdir()
 


### PR DESCRIPTION
we don't really benefit from cachew much here, and cachew.NTBinder has performance overhead/extra dependency small amount of manual sqlite binding is a relatively small price to pay

plus some minor refactoring -- start moving database related stuff to promnesia.database