### PR TITLE
Use setup.py to install dependencies in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -305,6 +305,7 @@ dmypy.json
 
 **/node_modules
 .idea
+.coverage*
 
 
 ######### NOTE: stuff above is from .gitignore
@@ -312,4 +313,12 @@ dmypy.json
 .git
 .ci  # otherwise build context is invalidated over and over again
 
+.circleci
+.github
+benchmarks
+ci
+doc
+docker/user_data
+docker/docker_files/indexer-config.py.example
+extension
 extension/dist

--- a/.dockerignore
+++ b/.dockerignore
@@ -305,7 +305,6 @@ dmypy.json
 
 **/node_modules
 .idea
-.coverage*
 
 
 ######### NOTE: stuff above is from .gitignore
@@ -313,12 +312,4 @@ dmypy.json
 .git
 .ci  # otherwise build context is invalidated over and over again
 
-.circleci
-.github
-benchmarks
-ci
-doc
-docker/user_data
-docker/docker_files/indexer-config.py.example
-extension
 extension/dist

--- a/docker/docker_files/Dockerfile
+++ b/docker/docker_files/Dockerfile
@@ -1,18 +1,13 @@
 FROM python:3
 
-RUN mkdir /user_data \
+RUN mkdir /user_data && \
     mkdir /usr/src/promnesia
 
 WORKDIR /usr/src/promnesia
-COPY src/ .
-COPY setup.py /usr/src/
+COPY . .
 
-#RUN python /usr/src/setup.py #LookupError: setuptools-scm was unable to detect version for '/usr/src/promnesia'.
-
-RUN pip install --no-cache-dir more_itertools pytz sqlalchemy cachew \
-                appdirs urlextract python-magic \
-                tzlocal \
-                logzero HPI beautifulsoup4 lxml mistletoe orgparse dataset fastapi uvicorn
+ARG VERSION=0
+RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PROMNESIA=${VERSION}  pip install --no-cache-dir -e .[all]
 
 ENV PPATH=/usr/src/promnesia:${PPATH}
 VOLUME /user_data

--- a/docker/docker_files/Dockerfile
+++ b/docker/docker_files/Dockerfile
@@ -4,7 +4,8 @@ RUN mkdir /user_data && \
     mkdir /usr/src/promnesia
 
 WORKDIR /usr/src/promnesia
-COPY . .
+COPY setup.py ./
+COPY ./src ./src
 
 ARG VERSION=0
 RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PROMNESIA=${VERSION}  pip install --no-cache-dir -e .[all]

--- a/docker/docker_files/Dockerfile-indexer
+++ b/docker/docker_files/Dockerfile-indexer
@@ -1,6 +1,7 @@
 FROM promnesia:latest
 
-RUN apt-get update && apt-get install -y cron
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y cron && rm -rf /var/lib/apt/lists/*
 
 COPY docker/docker_files/indexer-entrypoint.sh /
 ENTRYPOINT ["/indexer-entrypoint.sh"]

--- a/docker/docker_files/docker-compose.yaml
+++ b/docker/docker_files/docker-compose.yaml
@@ -1,5 +1,7 @@
 version: '3.3'
 
+name: promnesia
+
 services:
   server:
     image: promnesia

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 cd "$(dirname "$0")"
-docker-compose -f docker_files/docker-compose.yaml build && docker-compose -f docker_files/docker-compose.yaml up
+docker-compose -f docker_files/docker-compose.yaml build --build-arg VERSION="$(git describe | cut -f1 -d"-")" && docker-compose -f docker_files/docker-compose.yaml up
 
 


### PR DESCRIPTION
While building from the Dockerfile, I ran into some issues caused by pip resolving sqlalchemy to v1 instead of v2. This PR changes the Dockerfile to install directly from setup.py, rather than indirectly from a list of dependencies, to hopefully prevent issues like this from coming up in the future.

It looks like the reason we originally went with the individual dependencies approach is because setuptools-scm needs to get the version from the git history. Since we don't want to bloat the container by copying the entire git history into it, setuptools-scm can't find the version and the installation fails. Since then, it looks like setuptools-scm has added an override environment variable which we can use to pass in a version explicitly during the build.