### PR TITLE
sources.takeout: add support for new youtube csv format

### DIFF
--- a/src/promnesia/sources/takeout.py
+++ b/src/promnesia/sources/takeout.py
@@ -46,8 +46,8 @@ def index() -> Results:
     except ImportError:
         # warn user to upgrade google_takeout_parser
         warnings.warn("Please upgrade google_takeout_parser (`pip install -U google_takeout_parser`) to support the new format for youtube comments")
-        CSVYoutubeComment = YoutubeCSVStub
-        CSVYoutubeLiveChat = YoutubeCSVStub
+        CSVYoutubeComment = YoutubeCSVStub  # type: ignore[misc,assignment]
+        CSVYoutubeLiveChat = YoutubeCSVStub  # type: ignore[misc,assignment]
 
     def warn_once_if_not_seen(e: Any) -> Iterable[Exception]:
         et_name = type(e).__name__


### PR DESCRIPTION
google takeout recently changed the format to CSV files for youtube comments, I added support for it to [google_takeout_parser](https://github.com/seanbreckenridge/google_takeout_parser/compare/v0.1.8...v0.1.10) a few weeks ago.

I haven't taken a stab at trying to de-dupe comments that exist in the old HTML format and the new CSV one yet, it is [on my todos](https://github.com/seanbreckenridge/google_takeout_parser/issues/65), but I thought it would be good to get this in here so that new people making an export can at least get access to their comments. There might be some duplication but better than erroring or not existing

this is very basic right now, it does not have any error checking, so if the user is on an old version of `google_takeout_parser`, this will just error. Should I add a warning message in the ImportError reminding them to upgrade? Wasnt sure if that was too much

If theres anything else you think should be changed/added for this, let me know
