### PR TITLE
sources.takeout: use reconstruct_comment_content directly to workaround weird formatted json data in takeout

### DIFF
--- a/src/promnesia/sources/filetypes.py
+++ b/src/promnesia/sources/filetypes.py
@@ -121,6 +121,7 @@ TYPE2IDX.update({
     'font/woff': ignore,
     'text/x-Algol68': ignore,  # ugh some license file had this?? maybe always index text/ as text?
     'text/x-bytecode.python': ignore,  # todo ignore all x-bytecode?
+    'text/calendar': ignore,
 
     # TODO not sure what to do about these..
     'application/octet-stream': handle_later,

--- a/src/promnesia/sources/takeout.py
+++ b/src/promnesia/sources/takeout.py
@@ -4,7 +4,6 @@ Uses HPI [[https://github.com/karlicoss/HPI/blob/master/doc/MODULES.org#mygoogle
 
 from __future__ import annotations
 
-import json
 import warnings
 from typing import Any, Iterable, NamedTuple
 
@@ -142,7 +141,7 @@ def index() -> Results:
                     url=url, dt=e.dt, context=e.content, locator=Loc(title=e.content, href=url)
                 )
         elif imported_yt_csv_models and isinstance(e, CSVYoutubeComment):
-            contentJSON = json.loads(e.contentJSON)
+            contentJSON = e.contentJSON
             content = reconstruct_comment_content(contentJSON, format='text')
             if isinstance(content, Exception):
                 yield content
@@ -160,7 +159,7 @@ def index() -> Results:
                 url=e.video_url, dt=e.dt, context=content, locator=Loc(title=context, href=e.video_url)
             )
         elif imported_yt_csv_models and isinstance(e, CSVYoutubeLiveChat):
-            contentJSON = json.loads(e.contentJSON)
+            contentJSON = e.contentJSON
             content = reconstruct_comment_content(contentJSON, format='text')
             if isinstance(content, Exception):
                 yield content


### PR DESCRIPTION
see https://github.com/seanbreckenridge/google_takeout_parser/pull/79