### PR TITLE
Update documentation to point correct location for obsidian and logseq sources

### DIFF
--- a/doc/SOURCES.org
+++ b/doc/SOURCES.org
@@ -94,8 +94,8 @@ for f in sorted((src / 'promnesia/sources').rglob('*.py')):
   - discovers files recursively
   - guesses the format (orgmode/markdown/json/etc) by the extension/MIME type
   - can index most of plaintext files, including source code!
-  - autodetects Obsidian vault and adds `obsidian://` app protocol support [[file:../src/promnesia/sources/obsidian.py][promnesia.sources.obsidian]]
-  - autodetects Logseq graph and adds `logseq://` app protocol support [[file:../src/promnesia/sources/logseq.py][promnesia.sources.logseq]]
+  - autodetects Obsidian vault and adds `obsidian://` app protocol support [[file:../src/promnesia/sources/auto_obsidian.py][promnesia.sources.obsidian]]
+  - autodetects Logseq graph and adds `logseq://` app protocol support [[file:../src/promnesia/sources/auto_logseq.py][promnesia.sources.logseq]]
 
 - [[file:../src/promnesia/sources/browser.py][promnesia.sources.browser]]
 

--- a/src/promnesia/sources/auto.py
+++ b/src/promnesia/sources/auto.py
@@ -2,8 +2,8 @@
 - discovers files recursively
 - guesses the format (orgmode/markdown/json/etc) by the extension/MIME type
 - can index most of plaintext files, including source code!
-- autodetects Obsidian vault and adds `obsidian://` app protocol support [[file:../src/promnesia/sources/obsidian.py][promnesia.sources.obsidian]]
-- autodetects Logseq graph and adds `logseq://` app protocol support [[file:../src/promnesia/sources/logseq.py][promnesia.sources.logseq]]
+- autodetects Obsidian vault and adds `obsidian://` app protocol support [[file:../src/promnesia/sources/auto_obsidian.py][promnesia.sources.obsidian]]
+- autodetects Logseq graph and adds `logseq://` app protocol support [[file:../src/promnesia/sources/auto_logseq.py][promnesia.sources.logseq]]
 """
 
 from __future__ import annotations


### PR DESCRIPTION


The documentation for both obsidian and logseq point to the `obsidian.py` and `logseq.py` files, whereas the correct path should be `auto_obsidian.py` and `auto_logseq.py`
Updated the documentation to reflect the same.