### PR TITLE
general: set min version to 3.12; update ci to run 3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,15 +30,13 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13', '3.14']
         exclude: [
             # windows runners are pretty scarce, so let's only run lowest and highest python version
-            {platform: windows-latest, python-version: '3.11'},
-            {platform: windows-latest, python-version: '3.12'},
+            {platform: windows-latest, python-version: '3.13'},
 
             # same, macos is a bit too slow and ubuntu covers python quirks well
-            {platform: macos-latest  , python-version: '3.11'},
-            {platform: macos-latest  , python-version: '3.12'},
+            {platform: macos-latest  , python-version: '3.13'},
         ]
 
     runs-on: ${{ matrix.platform }}
@@ -50,16 +48,16 @@ jobs:
     # ugh https://github.com/actions/toolkit/blob/main/docs/commands.md#path-manipulation
     - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
         fetch-depth: 0  # nicer to have all git history when debugging/for tests
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
       
-    - uses: astral-sh/setup-uv@v5
+    - uses: astral-sh/setup-uv@v7
       with:
         enable-cache: false  # we don't have lock files, so can't use them as cache key
 
@@ -100,16 +98,16 @@ jobs:
     # ugh https://github.com/actions/toolkit/blob/main/docs/commands.md#path-manipulation
     - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
         fetch-depth: 0  # pull all commits to correctly infer vcs version
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
-    - uses: astral-sh/setup-uv@v5
+    - uses: astral-sh/setup-uv@v7
       with:
         enable-cache: false  # we don't have lock files, so can't use them as cache key
 
@@ -129,7 +127,7 @@ jobs:
       name: 'promnesia'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
         fetch-depth: 0  # nicer to have all git history when debugging/for tests
@@ -164,7 +162,7 @@ jobs:
   end2end_tests_chrome:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
     - uses: mxschmitt/action-tmate@v3
@@ -174,7 +172,7 @@ jobs:
   end2end_tests_firefox:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
     - uses: mxschmitt/action-tmate@v3
@@ -186,7 +184,7 @@ jobs:
     # todo run on macos too?
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
     - uses: mxschmitt/action-tmate@v3

--- a/doc/config.py
+++ b/doc/config.py
@@ -47,21 +47,19 @@ SOURCES = [
         auto.index,
         # NOTE: you'd need to specify your own filesystem path here
         '/path/to/my/blog',
-
         # you can specify optional name, so you can see where the URL is coming from within the extension
         name='blog',
     ),
-
+    #
     # we can index another path under a different name (for convenience)
     Source(
         auto.index,
         # NOTE: you'd need to specify your own filesystem path here
         '/path/to/personal/notes',
         ignored=['*.html'],  # we can exclude certain files if we want
-
         name='notes',
     ),
-
+    #
     # we can index Logseq graph: extract links from Org-mode and Markdown files
     Source(
         auto.index,
@@ -69,23 +67,22 @@ SOURCES = [
         ignored=['*/.obsidian/*', '*/logseq/*', '*/assets/*'],
         name='logseq',
     ),
-
+    #
     # will clone the repository and index its contents!
     Source(
-        guess.index, # you could also use 'vcs.index', but auto can handle it anyway
+        guess.index,  # you could also use 'vcs.index', but auto can handle it anyway
         'https://github.com/karlicoss/exobrain',
         name='exobrain',
     ),
-
-
+    #
     # Uses the output of telegram_backup tool: https://github.com/fabianonline/telegram_backup#usage
     # name will be set to 'telegram' by default
     Source(
         telegram,
         '/data/telegram/database.sqlite',
-        #http_only=None  # harvest alsoIP-addresses & plain domain-names
+        # http_only=None  # harvest alsoIP-addresses & plain domain-names
     ),
-
+    #
     # Uses all local SQLite files found in your Viber Desktop configurations
     # (one directory for each telephone number):
     #     ~/.ViberPC/**/viber.db
@@ -93,37 +90,36 @@ SOURCES = [
     # You may modify that by providing a 2nd ``Source()`` argument.
     Source(
         viber,
-        #"path/to/viber-sql",
-        #http_only=None  # harvest alsoIP-addresses & plain domain-names
+        # "path/to/viber-sql",
+        # http_only=None  # harvest alsoIP-addresses & plain domain-names
     ),
-
+    #
     # When path(s) given, uses the SQLite inside Signal-Desktop's configuration directory
     # (see the sources for more parameters & location of the db-file for each platform)
     signal,
-
+    #
     # NOTE: to configure the following modules you need to set up HPI package (https://github.com/karlicoss/HPI#whats-inside)
     # see HPI setup guide    : https://github.com/karlicoss/HPI/blob/master/doc/SETUP.org
     # and HPI usage examples': https://github.com/karlicoss/HPI/blob/master/doc/SETUP.org#usage-examples
     ####
     Source(hypothesis.index),
     Source(takeout.index),
-
+    #
     # you can also be less verbose in config, if you prefer
     Source(roamresearch),
     Source(rss, name='custom name'),
-
+    #
     # or:
     fbmessenger.index,
-
+    #
     # or even just:
     pocket,
     instapaper,
-
-
+    #
+    #
     # sometimes lambdas are useful for config hacking/avoiding early imports
     lambda: twitter.index(),
 ]
-
 
 
 ''''
@@ -153,15 +149,14 @@ FILTERS = [
     'web.telegram.org/#/im',
     'vk.com/im',
     '192.168.0.',
-
+    #
     # you can use regexes too!
     'redditmedia.com.*.(jpg|png|gif)',
 ]
 
-'''
-Optional setting.
-Can be useful to hack (e.g. rewrite/filter/etc) the visits before inserting in the database.
-'''
+
+# Optional setting.
+# Can be useful to hack (e.g. rewrite/filter/etc) the visits before inserting in the database.
 def HOOK(v):
     # filter out 'boring' github visits without contexts
     if 'github.com' in v.norm_url:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "promnesia[server]",
     ##
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 
 ## these need to be set if you're planning to upload to pypi
 description = "Enhancement of your browsing history"
@@ -117,7 +117,7 @@ typecheck = [
     { include-group = "testing" },
     "mypy",
     "lxml",  # for mypy coverage
-    "ty>=0.0.1a21",
+    "ty>=0.0.1a22",
 
     "types-psutil",
     "types-requests",

--- a/scripts/browser_history.py
+++ b/scripts/browser_history.py
@@ -5,7 +5,7 @@ import filecmp
 import logging
 import sys
 import warnings
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from subprocess import check_output
 
@@ -70,7 +70,7 @@ def backup_history(browser: Browser, to: Path, profile: str = '*', pattern=None)
     assert to.is_dir()
     logger = get_logger()
 
-    now = format_dt(datetime.now(tz=timezone.utc))
+    now = format_dt(datetime.now(tz=UTC))
 
     path = get_path(browser, profile=profile)
 

--- a/src/promnesia/common.py
+++ b/src/promnesia/common.py
@@ -10,14 +10,14 @@ import warnings
 from collections.abc import Callable, Iterable, Sequence
 from contextlib import contextmanager
 from copy import copy
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 from functools import lru_cache
 from glob import glob
 from pathlib import Path
 from subprocess import PIPE, Popen, run
 from timeit import default_timer as timer
 from types import ModuleType
-from typing import TYPE_CHECKING, NamedTuple, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, NamedTuple
 from zoneinfo import ZoneInfo
 
 import platformdirs
@@ -27,8 +27,7 @@ from .cannon import canonify
 
 _is_windows = os.name == 'nt'
 
-T = TypeVar('T')
-Res: TypeAlias = T | Exception
+type Res[T] = T | Exception
 
 PathIsh = str | Path
 
@@ -265,7 +264,7 @@ def extract_urls(s: str, *, syntax: Syntax = '') -> list[Url]:
 
 
 def from_epoch(ts: int) -> datetime:
-    return datetime.fromtimestamp(ts, tz=timezone.utc)
+    return datetime.fromtimestamp(ts, tz=UTC)
 
 
 def join_tags(tags: Iterable[str]) -> str:

--- a/src/promnesia/compare.py
+++ b/src/promnesia/compare.py
@@ -6,7 +6,6 @@ import logging
 import sys
 from collections.abc import Iterator, Sequence
 from pathlib import Path
-from typing import TypeVar
 
 from .common import DbVisit, PathWithMtime, Url
 from .database.load import row_to_db_visit
@@ -22,10 +21,7 @@ def get_logger():
 # TODO return error depending on severity?
 
 
-T = TypeVar('T')
-
-
-def eliminate_by(sa: Sequence[T], sb: Sequence[T], key):
+def eliminate_by[T](sa: Sequence[T], sb: Sequence[T], key):
     def make_dict(s: Sequence[T]) -> dict[str, list[T]]:
         res: dict[str, list[T]] = {}
         for a in s:

--- a/src/promnesia/sources/browser_legacy.py
+++ b/src/promnesia/sources/browser_legacy.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import unquote
 
@@ -199,7 +199,7 @@ class Chrome(Extr):
 # yep, tested it and looks like utc
 def chrome_time_to_utc(chrome_time: int) -> datetime:
     epoch = (chrome_time / 1_000_000) - 11644473600
-    return datetime.fromtimestamp(epoch, timezone.utc)
+    return datetime.fromtimestamp(epoch, UTC)
 
 
 def _row2visit_firefox(row: sqlite3.Row, loc: Loc) -> Visit:
@@ -217,7 +217,7 @@ def _row2visit_firefox(row: sqlite3.Row, loc: Loc) -> Visit:
     else:
         # milliseconds
         ts /= 1_000
-    dt = datetime.fromtimestamp(ts, timezone.utc)
+    dt = datetime.fromtimestamp(ts, UTC)
     url = unquote(url)  # firefox urls are all quoted
     return Visit(
         url=url,
@@ -257,7 +257,7 @@ class Safari(Extr):
     def row2visit(row: sqlite3.Row, loc: Loc) -> Visit:
         url = row['url']
         ts = row['visit_time'] + 978307200  # https://stackoverflow.com/a/34546556/16645
-        dt = datetime.fromtimestamp(ts, timezone.utc)
+        dt = datetime.fromtimestamp(ts, UTC)
 
         return Visit(
             url=url,

--- a/src/promnesia/sources/rss.py
+++ b/src/promnesia/sources/rss.py
@@ -2,12 +2,12 @@
 Uses [[https://github.com/karlicoss/HPI][HPI]] for RSS data.
 '''
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from promnesia.common import Loc, Results, Visit
 
 # arbitrary,  2011-11-04 00:05:23.283+00:00
-default_datetime = datetime.fromtimestamp(1320365123, tz=timezone.utc)
+default_datetime = datetime.fromtimestamp(1320365123, tz=UTC)
 # TODO FIXME allow for visit not to have datetime?
 # I.e. even having context is pretty good!
 

--- a/src/promnesia/sources/takeout_legacy.py
+++ b/src/promnesia/sources/takeout_legacy.py
@@ -29,7 +29,7 @@ def index() -> Results:
 
 import json
 from collections.abc import Iterable
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from itertools import chain
 from pathlib import Path
 
@@ -124,7 +124,7 @@ def read_browser_history_json(takeout: TakeoutPath) -> Iterable[Visit]:
     hist = j['Browser History']
     for item in hist:
         url = item['url']
-        time = datetime.fromtimestamp(item['time_usec'] / 10**6, tz=timezone.utc)
+        time = datetime.fromtimestamp(item['time_usec'] / 10**6, tz=UTC)
         # TODO any more interesitng info?
         yield Visit(
             url=url,

--- a/src/promnesia/sources/telegram_legacy.py
+++ b/src/promnesia/sources/telegram_legacy.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 from textwrap import dedent
-from typing import TypeVar
 from urllib.parse import unquote  # TODO mm, make it easier to rememember to use...
 
 from promnesia.common import (
@@ -22,10 +21,8 @@ from promnesia.common import (
 
 from ..sqlite import sqlite_connection
 
-T = TypeVar("T")
 
-
-def unwrap(res: T | Exception) -> T:
+def unwrap[T](res: T | Exception) -> T:
     if isinstance(res, Exception):
         raise res
     return res

--- a/src/promnesia/tests/common.py
+++ b/src/promnesia/tests/common.py
@@ -9,7 +9,7 @@ from collections.abc import Iterator
 from contextlib import closing, contextmanager
 from pathlib import Path
 from textwrap import dedent
-from typing import NoReturn, TypeVar
+from typing import NoReturn
 
 import pytest
 
@@ -97,11 +97,7 @@ def reset_filters():
         extract.filters.cache_clear()
 
 
-# TODO could be a TypeGuard from 3.10
-V = TypeVar('V')
-
-
-def unwrap(r: Res[V]) -> V:
+def unwrap[V](r: Res[V]) -> V:
     assert not isinstance(r, Exception), r
     return r
 

--- a/src/promnesia/tests/sources/test_takeout.py
+++ b/src/promnesia/tests/sources/test_takeout.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from my.core.cfg import tmp_config
@@ -51,6 +51,6 @@ def test_takeout_zip(no_cachew) -> None:
         hour=5,
         minute=48,
         second=23,
-        tzinfo=timezone.utc,
+        tzinfo=UTC,
     )
     assert unwrap(vis).dt == edt

--- a/src/promnesia/tests/test_db_dump.py
+++ b/src/promnesia/tests/test_db_dump.py
@@ -4,7 +4,7 @@ from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any
+from typing import Any, cast
 from zoneinfo import ZoneInfo
 
 # NOTE: pytest ... -s --hypothesis-verbosity=debug is useful for seeing what hypothesis is doing
@@ -22,10 +22,13 @@ from .common import (
     running_on_ci,
 )
 
-HSETTINGS: dict[str, Any] = {
-    'derandomize': True,
-    'deadline': timedelta(seconds=2),  # sometimes slow on ci
-}
+HSETTINGS = cast(
+    dict[str, Any],
+    {
+        'derandomize': True,
+        'deadline': timedelta(seconds=2),  # sometimes slow on ci
+    },
+)
 
 
 def test_no_visits(tmp_path: Path) -> None:

--- a/src/promnesia/tests/test_extract.py
+++ b/src/promnesia/tests/test_extract.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from more_itertools import ilen
@@ -18,9 +18,9 @@ def test_with_error() -> None:
         pass
 
     def indexer():
-        yield Visit(url='http://test1', dt=datetime.fromtimestamp(0, tz=timezone.utc), locator=Loc.make('whatever'))
+        yield Visit(url='http://test1', dt=datetime.fromtimestamp(0, tz=UTC), locator=Loc.make('whatever'))
         yield ExtractionError()
-        yield Visit(url='http://test2', dt=datetime.fromtimestamp(0, tz=timezone.utc), locator=Loc.make('whatever'))
+        yield Visit(url='http://test2', dt=datetime.fromtimestamp(0, tz=UTC), locator=Loc.make('whatever'))
 
     [v1, e, v2] = extract_visits(source=Source(indexer), src='whatever')
     assert isinstance(v1, DbVisit)

--- a/tests/common.py
+++ b/tests/common.py
@@ -7,7 +7,6 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from functools import wraps
 from pathlib import Path
-from typing import TypeVar
 
 import pytest
 import requests
@@ -72,9 +71,6 @@ def local_http_server(path: Path) -> Iterator[str]:
         yield endpoint
 
 
-T = TypeVar('T')
-
-
-def notnone(x: T | None) -> T:
+def notnone[T](x: T | None) -> T:
     assert x is not None
     return x

--- a/tests/end2end_test.py
+++ b/tests/end2end_test.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from time import sleep
-from typing import TypeVar
 
 import pytest
 from addon import (
@@ -115,8 +114,7 @@ with_browser_tests = pytest.mark.skipif(
 )
 
 
-X = TypeVar('X')
-IdType = Callable[[X], X]
+type IdType[X] = Callable[[X], X]
 
 
 def browsers(*br: Browser) -> IdType:


### PR DESCRIPTION
It's a bit of a toll to support so many versions, especially with new 3.12 type syntax and other goodies.

With pyenv/uv these days using custom python version is far easier than before and even preferred.