### PR TITLE
extension: some workarounds to always display extension icon

### DIFF
--- a/extension/generate_manifest.js
+++ b/extension/generate_manifest.js
@@ -69,6 +69,12 @@ export function generateManifest({
         "default_icon": "images/ic_not_visited_48.png",
         "default_title": "Show promnesia sidebar",
     }
+    if (target === T.FIREFOX) { // only supported in firefox https://github.com/mozilla/web-ext/issues/2874
+        // otherwise firefox hides the icon under the "puzzle piece" menu
+        // At the very least it's annoying for testing, but also for promnesia it makes sense to show anyway
+        action["default_area"] = "navbar"
+        // in chrome, we're achieving the same thing by injecting "key" (see below)
+    }
 
 
     const endpoints = (domain) => [
@@ -242,6 +248,11 @@ export function generateManifest({
                 },
             },
         }
+    }
+    if (target === T.CHROME) {
+        // to achieve stable extension id, needs "key" in manifest.json (this is injected in generate_manifest)
+        // see https://developer.chrome.com/docs/extensions/reference/manifest/key
+        manifest['key'] = "cHJvbW5lc2lhLWV4dGVuc2lvbi1pZA=="  // this needs to be a base64 string
     }
     return manifest
 }

--- a/tests/webdriver_utils.py
+++ b/tests/webdriver_utils.py
@@ -229,6 +229,19 @@ def get_webdriver(
         # https://issues.chromium.org/issues/409441960
         cr_options.add_experimental_option('enableExtensionTargets', value=True)
 
+        # to achieve stable id, needs "key" in manifest.json (this is injected in generate_manifest)
+        # see https://developer.chrome.com/docs/extensions/reference/manifest/key
+        _CHROME_EXTENSION_ID = "banagbhbaajfliafnjclpabfdadjghki"
+
+        cr_options.add_experimental_option(
+            "prefs",
+            {
+                # always pin extension in toolbar, otherwise very annoying to test
+                # not possible to configure in manifest directly (unlike in firefox https://github.com/mozilla/web-ext/issues/2874)
+                "extensions.pinned_extensions": [_CHROME_EXTENSION_ID]
+            },
+        )
+
         # generally 'selenium manager' downloads the correct driver version itself
         chromedriver_bin: str | None = None  # default
 


### PR DESCRIPTION
This makes testing easier, otherwise it's always pinned in the overflow menu