### PR TITLE
end2end tests: implement more robust checks for extension state

### DIFF
--- a/extension/src/selenium_bridge.js
+++ b/extension/src/selenium_bridge.js
@@ -8,9 +8,27 @@ for (const x of [
     'selenium-bridge-search',
 ]) {
     document.addEventListener(x, () => {
-        chrome.runtime.sendMessage(x)
+        browser.runtime.sendMessage(x)
     })
 }
+
+
+// 'reverse bridge': allows reading extension state from webdriver
+document.addEventListener('selenium-bridge-get-state', async (event) => {
+    // clear previous state
+    delete document.documentElement.dataset.seleniumBridgeState
+    // we use a timestamp to make sure we don't read some stale response
+    const timestamp_ms = event.detail.timestamp_ms
+    let state
+    try {
+        state = await browser.runtime.sendMessage('selenium-bridge-get-state')
+    } catch (error) {
+        console.error(error)
+        state = {error: error}
+    }
+    state.timestamp_ms = timestamp_ms
+    document.documentElement.dataset.seleniumBridgeState = JSON.stringify(state)
+})
 
 // special variable to check against when we use selenium bridge
 // otherwise it's possible that the script isn't injected yet, and then the event wouldn't get received

--- a/tests/test_end2end.py
+++ b/tests/test_end2end.py
@@ -166,8 +166,14 @@ def test_blacklist_custom(addon: Addon, driver: Driver) -> None:
     addon.configure(port='12345', blacklist=('stackoverflow.com',))
     driver.get('https://stackoverflow.com/questions/27215462')
 
+    for _ in timeout(1.0):
+        # NOTE: need to poll here because we might observe state beforethe page was fully loaded
+        if 'Blacklisted: User-defined' in addon.helper.get_extension_state()['title']:
+            break
+    confirm('page should be blacklisted (black icon)')
+
     addon.activate()
-    confirm('page should be blacklisted (black icon), you should see an error notification')
+    confirm('you should see an error notification about excluded page')
     # make sure there is not even the frame for blacklisted page
     assert not addon.sidebar.available
 
@@ -177,8 +183,12 @@ def test_blacklist_custom(addon: Addon, driver: Driver) -> None:
     driver.back()
     driver.refresh()
 
-    addon.sidebar.open()
+    addon.sidebar.open()  # this checks that sidebar is visible as well
     confirm('sidebar: should be visible')
+
+    # NOTE hmm depending on how fast the test is running it might be no data or 1 (or more?) previous visits, e.g. when we test interactively
+    assert 'Blacklisted' not in addon.helper.get_extension_state()['title']
+    confirm('icon: grey/purple')
 
 
 @browsers()
@@ -186,8 +196,14 @@ def test_blacklist_builtin(addon: Addon, driver: Driver) -> None:
     addon.configure(port='12345')
     driver.get('https://www.hsbc.co.uk/mortgages/')
 
+    for _ in timeout(1.0):
+        # NOTE: need to poll here because we might observe state beforethe page was fully loaded
+        if "Blacklisted: 'Banking' filterlist" in addon.helper.get_extension_state()['title']:
+            break
+    confirm('page should be blacklisted (black icon)')
+
     addon.activate()
-    confirm('page should be blacklisted (black icon), your should see an error notification')
+    confirm('your should see an error notification about excluded page')
     # make sure there is not even the frame for blacklisted page
     assert not addon.sidebar.available
 
@@ -199,6 +215,10 @@ def test_blacklist_builtin(addon: Addon, driver: Driver) -> None:
 
     addon.sidebar.open()
     confirm('sidebar: should be visible')
+
+    # NOTE hmm depending on how fast the test is running it might be no data or 1 (or more?) previous visits, e.g. when we test interactively
+    assert 'Blacklisted' not in addon.helper.get_extension_state()['title']
+    confirm('icon: grey/purple')
 
 
 @browsers()


### PR DESCRIPTION
Implement 'reverse' selenium bridge to read extension badge state, allows to properly test excludelists in headless mode