### PR TITLE
end2end tests: some cleanup

### DIFF
--- a/tests/testdata/test_multiple_page_updates/index.html
+++ b/tests/testdata/test_multiple_page_updates/index.html
@@ -5,8 +5,9 @@
 let index = 0
 const update_title = () => {
     document.title = `title ${index}`
+    window.location.hash = `#update-${index}`
     index += 1
-    setTimeout(update_title, 50)
+    setTimeout(update_title, 50)  // update every 50ms
 }
 update_title()
 


### PR DESCRIPTION
- test_add_to_blacklist_context_menu: filter browsers to gui only properly to avoid starting it up
- test_sidebar_basic: remove udemy test that wasn't working anyway. it's now covered by multiple_page_updates test
- test_multiple_page_update: remove sleep and make more robust, also update url fragment just in case