### PR TITLE
end2end tests: replace httpbin with postman-echo for delayed load test

### DIFF
--- a/tests/test_end2end.py
+++ b/tests/test_end2end.py
@@ -625,7 +625,7 @@ def test_click_before_page_loaded(
 </head>
 <body>
     <h1>Page loading...</h1>
-    <img src="https://httpbin.org/delay/{delay_s}" alt="Delayed resource">
+    <img src="https://postman-echo.com/delay/{delay_s}" alt="Delayed resource">
     <p>This image takes {delay_s} seconds to load</p>
 </body>
 </html>


### PR DESCRIPTION
seems like httpbin sometimes can take longer than the specified number of seconds to wait, which results in flaky test