### PR TITLE
extension: fix caching logic for blacklist to prevent stale cache with error response

### DIFF
--- a/extension/src/common.ts
+++ b/extension/src/common.ts
@@ -300,8 +300,14 @@ export async function fetch_max_stale(url: string, {max_stale}: {max_stale: numb
      */
 
     // if it's not cached, it will make a real request
-    // anso works offline (returns cached response with no errors)
+    // also works offline (returns cached response with no errors)
     const cached_resp = await fetch(url, {cache: 'force-cache'}).then(rejectIfHttpError)
+
+    if (!cached_resp.ok) {
+        // if cached response is an error, skip the cache and fetch fresh
+        return fetch(url).then(rejectIfHttpError)
+    }
+
     const expires = cached_resp.headers.get('expires')
     // not sure if it's possible not to have 'expires'
     const stale_ms = new Date().getTime() - new Date(expires == null ? 0 : expires).getTime()

--- a/tests/test_end2end.py
+++ b/tests/test_end2end.py
@@ -165,8 +165,10 @@ def test_bad_port(addon: Addon, driver: Driver) -> None:
 
 @browsers()
 def test_blacklist_custom(addon: Addon, driver: Driver) -> None:
-    addon.configure(port='12345', blacklist=('stackoverflow.com',))
-    driver.get('https://stackoverflow.com/questions/27215462')
+    # FIXME hmm seems like doesn't work if we use just expandtesting.com
+    # maybe it should? feels like reasonable for blacklist...
+    addon.configure(port='12345', blacklist=('practice.expandtesting.com',))
+    driver.get('https://practice.expandtesting.com/infinite-scroll')
 
     for _ in timeout(2.0):
         # NOTE: need to poll here because we might observe state beforethe page was fully loaded


### PR DESCRIPTION
If you currently having an issue that your blacklist never works, clear browser cache and it should help.